### PR TITLE
OntologyTransform should be called once

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -14,6 +14,7 @@ kghub-downloader = "*"
 kgx = "*"
 koza = "*"
 biolink-model = "*"
+requests-cache = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = {version = ">=7.1.2"}

--- a/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}/transform.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}/transform.py
@@ -8,12 +8,7 @@ from {{cookiecutter.__project_slug}}.transform_utils.ontology import OntologyTra
 from {{cookiecutter.__project_slug}}.transform_utils.ontology.ontology_transform import ONTOLOGIES
 
 DATA_SOURCES = {
-    # "MondoTransform": OntologyTransform,
-    # "ChebiTransform": OntologyTransform,
-    "HPOTransform": OntologyTransform,
-    "ENVOTransform": OntologyTransform,
-    # "GOTransform": OntologyTransform,
-    # "OGMSTransform": OntologyTransform,
+    "OntologyTransform": OntologyTransform,
     # "DrugCentralTransform": DrugCentralTransform,
     # "OrphanetTransform": OrphanetTransform,
     # "OMIMTransform": OMIMTransform,

--- a/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}/transform_utils/atc/atc.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}/transform_utils/atc/atc.py
@@ -10,6 +10,7 @@ import os
 import shutil
 from pathlib import Path
 from typing import Optional, Union
+import requests_cache
 
 from koza.cli_runner import transform_source  # type: ignore
 
@@ -37,6 +38,9 @@ class ATCTransform(Transform):
         """
         source_name = "atc"
         super().__init__(source_name, input_dir, output_dir)
+        # Any data parsed via `requests` will be cached 
+        # and consecutive executions will be quicker
+        requests_cache.install_cache("atc_cache")
 
     def run(self, atc_file: Union[Optional[Path], Optional[str]] = None) -> None:
         """Set up the ATC for Koza and call the parse function."""

--- a/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}/transform_utils/example_transform/example_transform.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}/transform_utils/example_transform/example_transform.py
@@ -16,6 +16,7 @@ Output these two files:
 import os
 from pathlib import Path
 from typing import Optional, Union
+import requests_cache
 
 from transform_utils.transform import Transform
 
@@ -29,6 +30,9 @@ class YourTransform(Transform):
         """Instatiation part."""
         source_name = "some_unique_name"
         super().__init__(source_name, input_dir, output_dir)
+        # Any data parsed via `requests` will be cached 
+        # and consecutive executions will be quicker
+        requests_cache.install_cache("example_cache")
 
     def run(self, data_file: Union[Optional[Path], Optional[str]] = None):
         """Run the transformation."""


### PR DESCRIPTION
OntologyTransform should be called once. As per the cookiecutter now, it is called multiple times (n = number of ontologies that are part of the project). This is incorrect. This PR fixes it.

Also added `requests_cache` as a dependency which will be super useful to cache data extracted via `requests` calls. Also added a line showing how it can be used.